### PR TITLE
Refs #BKLG-434 - Rationalising Smith Images

### DIFF
--- a/src/Media/CroppingBundle/EventListener/MediaCroppingSubscriber.php
+++ b/src/Media/CroppingBundle/EventListener/MediaCroppingSubscriber.php
@@ -6,8 +6,7 @@ use Doctrine\Common\EventSubscriber;
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use Doctrine\ORM\EntityManager;
 use Media\CroppingBundle\Entity\MediaCropping;
-use Media\CroppingBundle\Repository\MediaCroppingRepository;#
-use Symfony\Component\DependencyInjection\Container;
+use Media\CroppingBundle\Repository\MediaCroppingRepository;
 use DateTime;
 use Exception;
 
@@ -24,13 +23,10 @@ class MediaCroppingSubscriber implements EventSubscriber
 
     /**
      * @param EntityManager $em
-     * @param MediaCroppingRepository $mediaCroppingRepository
      */
-    public function __construct(Container $container, MediaCroppingRepository $mediaCroppingRepository)
+    public function __construct(EntityManager $em)
     {
-        // WFT?????????????? Why is not working
-        $this->em = $container->get('doctrine.orm.entity_manager');
-        $this->mediaCroppingRepository = $mediaCroppingRepository;
+        $this->em = $em;
     }
 
     /**
@@ -57,7 +53,8 @@ class MediaCroppingSubscriber implements EventSubscriber
 
         if ($entity instanceof Media) {
             $mediaCroppingResizes = $this
-                ->mediaCroppingRepository
+                ->em
+                ->getRepository(MediaCropping::class)
                 ->findByEntityAndSize($media);
 
             foreach ($mediaCroppingResizes as $mediaCroppingResize) {

--- a/src/Media/CroppingBundle/EventListener/MediaCroppingSubscriber.php
+++ b/src/Media/CroppingBundle/EventListener/MediaCroppingSubscriber.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Media\CroppingBundle\EventListener;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\ORM\EntityManager;
+use Media\CroppingBundle\Entity\MediaCropping;
+use Media\CroppingBundle\Repository\MediaCroppingRepository;#
+use Symfony\Component\DependencyInjection\Container;
+use DateTime;
+use Exception;
+
+/**
+ * @package SmithOakMediaBundle\EventListener
+ */
+class MediaCroppingSubscriber implements EventSubscriber
+{
+    /** @var EntityManager $em */
+    protected $em;
+
+    /** @var MediaCroppingRepository $mediaCroppingRepository */
+    protected $mediaCroppingRepository;
+
+    /**
+     * @param EntityManager $em
+     * @param MediaCroppingRepository $mediaCroppingRepository
+     */
+    public function __construct(Container $container, MediaCroppingRepository $mediaCroppingRepository)
+    {
+        // WFT?????????????? Why is not working
+        $this->em = $container->get('doctrine.orm.entity_manager');
+        $this->mediaCroppingRepository = $mediaCroppingRepository;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSubscribedEvents(): array
+    {
+        return [
+            'postUpdate'
+        ];
+    }
+
+    /**
+     * After a crop update delete custom resizes
+     *
+     * @param LifecycleEventArgs $args
+     *
+     * @return void
+     */
+    public function postUpdate(LifecycleEventArgs $args): void
+    {
+        /** @var MediaCropping $entity */
+        $entity = $args->getObject();
+
+        if ($entity instanceof Media) {
+            $mediaCroppingResizes = $this
+                ->mediaCroppingRepository
+                ->findByEntityAndSize($media);
+
+            foreach ($mediaCroppingResizes as $mediaCroppingResize) {
+                $this->em->remove($mediaCroppingResize);
+            }
+
+            $this->em->flush();
+        }
+    }
+}

--- a/src/Media/CroppingBundle/EventListener/MediaSubscriber.php
+++ b/src/Media/CroppingBundle/EventListener/MediaSubscriber.php
@@ -90,8 +90,9 @@ class MediaSubscriber implements EventSubscriber
                     $new_crop->setContent($content, ['storage' => 'STANDARD', 'ACL' => 'public-read']);
 
                     $mediaCropping = new MediaCropping();
-                    $mediaCropping->setUpdatedAt(new DateTime('now'))
+                    $mediaCropping
                         ->setCreatedAt(new DateTime('now'))
+                        ->setUpdatedAt($mediaCropping->getCreatedAt())
                         ->setName($entity->getName())
                         ->setPath($newImagePath)
                         ->setEntity($entity->getId())

--- a/src/Media/CroppingBundle/Repository/MediaCroppingRepository.php
+++ b/src/Media/CroppingBundle/Repository/MediaCroppingRepository.php
@@ -22,6 +22,8 @@ class MediaCroppingRepository extends EntityRepository
             ->setParameter('media', $mediaCropping->getMedia())
             ->andWhere('mediaCropping.sizeKey LIKE :sizeKey')
             ->setParameter('sizeKey', "%{$mediaCropping->getSizeKey()}%")
+            ->andWhere('mediaCropping.id <> :id')
+            ->setParameter('id', $mediaCropping->getId())
             ->getQuery()
             ->getResult();
     }

--- a/src/Media/CroppingBundle/Repository/MediaCroppingRepository.php
+++ b/src/Media/CroppingBundle/Repository/MediaCroppingRepository.php
@@ -12,9 +12,9 @@ class MediaCroppingRepository extends EntityRepository
      *
      * @param MediaCropping $mediaCropping
      *
-     * @return array
+     * @return MediaCropping[]
      */
-    public function findByEntityAndSize(MediaCropping $mediaCropping)
+    public function findByEntityAndSize(MediaCropping $mediaCropping): array
     {
         return $this
             ->createQueryBuilder('mediaCropping')

--- a/src/Media/CroppingBundle/Repository/MediaCroppingRepository.php
+++ b/src/Media/CroppingBundle/Repository/MediaCroppingRepository.php
@@ -3,7 +3,26 @@
 namespace Media\CroppingBundle\Repository;
 
 use Doctrine\ORM\EntityRepository;
+use Media\CroppingBundle\Entity\MediaCropping;
 
 class MediaCroppingRepository extends EntityRepository
 {
+    /**
+     * @author Daniele Rostellato <daniele.rostellato@smithhotels.com>
+     *
+     * @param MediaCropping $mediaCropping
+     *
+     * @return array
+     */
+    public function findByEntityAndSize(MediaCropping $mediaCropping)
+    {
+        return $this
+            ->createQueryBuilder('mediaCropping')
+            ->where('mediaCropping.media = :media')
+            ->setParameter('media', $mediaCropping->getMedia())
+            ->andWhere('mediaCropping.sizeKey LIKE :sizeKey')
+            ->setParameter('sizeKey', "%{$mediaCropping->getSizeKey()}%")
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/Media/CroppingBundle/Resources/config/services.yml
+++ b/src/Media/CroppingBundle/Resources/config/services.yml
@@ -22,6 +22,8 @@ services:
         class: Media\CroppingBundle\EventListener\MediaCroppingSubscriber
         arguments:
             - '@doctrine.orm.entity_manager'
+            - '@sonata.media.filesystem.s3'
+            - '@sonata.media.provider.image'
         tags:
             - { name: doctrine.event_subscriber, connection: default }
 

--- a/src/Media/CroppingBundle/Resources/config/services.yml
+++ b/src/Media/CroppingBundle/Resources/config/services.yml
@@ -8,3 +8,15 @@ services:
         arguments: ['@service_container', '@doctrine.orm.entity_manager', '%media_cropping%']
         tags:
             - { name: doctrine.event_subscriber, connection: default }
+
+    media.cropping_bundle.repository.media_cropping_repository:
+        class: Doctrine\ORM\EntityRepository
+        factory: ['@doctrine.orm.entity_manager', getRepository]
+        arguments:
+            - Media\CroppingBundle\Entity\MediaCropping
+
+    media.cropping_bundle.services.media_resizing_helper:
+        class: Media\CroppingBundle\Services\MediaResizingHelper
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            - '@sonata.media.provider.image'

--- a/src/Media/CroppingBundle/Resources/config/services.yml
+++ b/src/Media/CroppingBundle/Resources/config/services.yml
@@ -21,8 +21,7 @@ services:
     media.cropping_bundle.event_listener.media_cropping_subscriber:
         class: Media\CroppingBundle\EventListener\MediaCroppingSubscriber
         arguments:
-            - '@service_container'
-            - '@media.cropping_bundle.repository.media_cropping_repository'
+            - '@doctrine.orm.entity_manager'
         tags:
             - { name: doctrine.event_subscriber, connection: default }
 

--- a/src/Media/CroppingBundle/Resources/config/services.yml
+++ b/src/Media/CroppingBundle/Resources/config/services.yml
@@ -3,17 +3,28 @@ services:
         class: Media\CroppingBundle\Configuration\Configuration
         arguments: [ '@service_container']
 
-    media.cropping_bundle.entity.media.subscriber:
-        class: Media\CroppingBundle\EventListener\MediaSubscriber
-        arguments: ['@service_container', '@doctrine.orm.entity_manager', '%media_cropping%']
-        tags:
-            - { name: doctrine.event_subscriber, connection: default }
-
     media.cropping_bundle.repository.media_cropping_repository:
         class: Doctrine\ORM\EntityRepository
         factory: ['@doctrine.orm.entity_manager', getRepository]
         arguments:
             - Media\CroppingBundle\Entity\MediaCropping
+
+    media.cropping_bundle.event_listener.media_subscriber:
+        class: Media\CroppingBundle\EventListener\MediaSubscriber
+        arguments:
+            - '@service_container'
+            - '@doctrine.orm.entity_manager'
+            - '%media_cropping%'
+        tags:
+            - { name: doctrine.event_subscriber, connection: default }
+
+    media.cropping_bundle.event_listener.media_cropping_subscriber:
+        class: Media\CroppingBundle\EventListener\MediaCroppingSubscriber
+        arguments:
+            - '@service_container'
+            - '@media.cropping_bundle.repository.media_cropping_repository'
+        tags:
+            - { name: doctrine.event_subscriber, connection: default }
 
     media.cropping_bundle.services.media_resizing_helper:
         class: Media\CroppingBundle\Services\MediaResizingHelper

--- a/src/Media/CroppingBundle/Services/MediaResizingHelper.php
+++ b/src/Media/CroppingBundle/Services/MediaResizingHelper.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Media\CroppingBundle\Services;
+
+use Doctrine\ORM\EntityManager;
+use Media\CroppingBundle\Entity\MediaCropping;
+use Sonata\MediaBundle\Provider\ImageProvider;
+use Application\Sonata\MediaBundle\Entity\Media;
+use Imagick;
+use Exception;
+use DateTime;
+
+/**
+ * Class MediaResizingHelper
+ *
+ * @package Media\CroppingBundle\Services
+ */
+class MediaResizingHelper
+{
+    /** @var EntityManager $entityManager */
+    protected $entityManager;
+
+    /** @var ImageProvider $imageProvider */
+    protected $imageProvider;
+
+    /**
+     * MediaResizingHelper constructor.
+     *
+     * @param EntityManager $entityManager
+     * @param ImageProvider $imageProvider
+     */
+    public function __construct(EntityManager $entityManager, ImageProvider $imageProvider)
+    {
+        $this
+            ->setEntityManager($entityManager)
+            ->setImageProvider($imageProvider)
+        ;
+    }
+
+    /**
+     * @author Daniele Rostellato <daniele.rostellato@smithhotels.com>
+     *
+     * @param MediaCropping $mediaCropping
+     * @param int $width
+     *
+     * @return MediaCropping
+     *
+     * @throws Exception
+     */
+    public function resizeCrop(MediaCropping $mediaCropping, int $width): MediaCropping
+    {
+        /** @var string $cropPath */
+        $cropPath = $this->getImageProvider()->getCdnPath($mediaCropping->getPath(), false);
+        $imagick = new Imagick($cropPath);
+
+        if ($imagick->getImageWidth() === $width) {
+            return $mediaCropping;
+        } elseif ($imagick->getImageWidth() < $width) {
+            throw new Exception('Requested a resize wider than the main image');
+        }
+
+        $imagick->resizeImage(
+            $width,
+            $width / ($imagick->getImageWidth() / $imagick->getImageHeight()),
+            Imagick::FILTER_UNDEFINED,
+            1
+        );
+
+        $srcArray = array_filter(explode('/', $cropPath));
+        array_pop($srcArray);
+        $parsedUrl = parse_url($cropPath);
+        $srcArray = array_filter(explode('/', $parsedUrl['path']));
+        array_pop($srcArray);
+        array_shift($srcArray);
+        $mediaPath = join('/', $srcArray);
+
+        $cropPathinfo = pathinfo($cropPath);
+        $newImageName = "{$cropPathinfo['filename']}-w$width.{$cropPathinfo['extension']}";
+        $newImagePath = "$mediaPath/$newImageName";
+
+        $newImage = $this->getImageProvider()->getFileSystem()->get($newImagePath, true);
+
+        $newImage->setContent($imagick->getImageBlob(), ['storage' => 'STANDARD', 'ACL' => 'public-read']);
+
+        $newMediaCropping = new MediaCropping();
+        $newMediaCropping
+            ->setCreatedAt(new DateTime('now'))
+            ->setUpdatedAt($newMediaCropping->getCreatedAt())
+            ->setName($newImageName)
+            ->setPath($newImagePath)
+            ->setEntity($mediaCropping->getEntity())
+            ->setEntityType('ApplicationSonataMediaBundle:Media')
+            ->setMedia($mediaCropping->getMedia())
+            ->setSizeKey("{$mediaCropping->getSizeKey()}-w$width")
+            ->setMeta($mediaCropping->getMeta())
+        ;
+
+        $this->getEntityManager()->persist($newMediaCropping);
+        $this->getEntityManager()->flush($newMediaCropping);
+
+        return $newMediaCropping;
+    }
+
+    /**
+     * @param EntityManager $entityManager
+     *
+     * @return self
+     */
+    protected function setEntityManager(EntityManager $entityManager): self
+    {
+        $this->entityManager = $entityManager;
+
+        return $this;
+    }
+
+    /**
+     * @return EntityManager
+     */
+    protected function getEntityManager(): EntityManager
+    {
+        return $this->entityManager;
+    }
+
+    /**
+     * @param ImageProvider $imageProvider
+     *
+     * @return self
+     */
+    public function setImageProvider(ImageProvider $imageProvider): self
+    {
+        $this->imageProvider = $imageProvider;
+
+        return $this;
+    }
+
+    /**
+     * @return ImageProvider
+     */
+    public function getImageProvider(): ImageProvider
+    {
+        return $this->imageProvider;
+    }
+}


### PR DESCRIPTION
[JIRA - BKLG-434](https://mrandmrssmith.atlassian.net/browse/BKLG-434)

**DO NOT MERGE UNTIL WE GET THE CROP SIZES**

# PRs (priority order)
- [SonataMediaCrop](https://github.com/penfold45/Sonata-Media-Crop/pull/3)
- [SmithCore](https://github.com/mrandmrssmith/SmithCoreBundle/pull/318)
- [UtilityBundle](https://github.com/mrandmrssmith/UtilityBundle/pull/12)
- [MMS](https://github.com/mrandmrssmith/mms/pull/682)
- MMS
   - Composer. Update UtilityBundle
   - Composer. Update SonataMediaCrop
- SmithSite
   - Composer. Update UtilityBundle
   - Composer. Update SmithCore

# Done

## New fields on

- Product / Product membership
- Itinerary
- Itineraries Boxes
- Membership Hubs

![screenshot from 2018-01-22 12-53-20](https://user-images.githubusercontent.com/6173422/35222415-b5895ee0-ff75-11e7-9073-f76a1b2223a4.png)

## `get_image_code_by_aspect_ratio`

New `get_image_code_by_aspect_ratio` function on SmithSite

```
{% set xxlarge_code = get_image_code_by_aspect_ratio(id, type, 'headerMedia', '4x3', 1000) %}

{% set xxlarge_code = get_image_code_by_aspect_ratio(ID, TYPE, FIELD, CROP[, WITDH]) %}
```

- One category only. That allows the Photo Editor's team to upload an image one time only
- `WIDTH` is an **optional parameter**.
    - Send the crop if `WIDTH` parameter is `null`
    - Create a resize on the fly (one time only) if the `WIDTH` is less than the crop's width

___

Grazie,
Lelle
